### PR TITLE
Issues/11 pattern matching

### DIFF
--- a/examples/server.squiggle
+++ b/examples/server.squiggle
@@ -1,22 +1,40 @@
 let (
     http = require("http"),
-    keys = global.Object.keys,
-    fromCharCode = global.String.fromCharCode,
-    omap = fn(f, obj)
-        let (g = fn(k) f(k, obj[k]))
-            map(g, keys(obj)),
-    NL = fromCharCode(10),
-    between = fn(x) fn(a, b) a ++ x ++ b,
-    concat = fn(a, b) a ++ b,
-    handler = fn(req, res) do {
-        console.log(req.method ++ " " ++ req.url);
-        res.writeHead(200, {"Content-Type": "text/plain"});
+    port = 1337,
+    address = "127.0.0.1",
+    Number = global.Number,
+    String = global.String,
+    NL = String.fromCharCode(10),
+    factorial = fn(n) match (n) {
+        case 0 => 1
+        case n => n * factorial(n - 1)
+    },
+    handlerFactorial = fn(x)
+        String(factorial(Number(x))),
+    parsePath = fn(s)
         let (
-            lines = omap(between(": "), req.headers),
-            str = reduce(concat, map(fn(x) x ++ NL, lines))
-        ) res.end(str);
+            mod = fn(s, i) Number(s.charAt(i) = "/"),
+            n = s.length,
+            a = mod(s, 0),
+            b = mod(s, n - 1)
+        ) s.slice(a, n - b).split("/"),
+    dispatchGet = fn(url) match (tail(url.split("/"))) {
+        case ["factorial", x] => handlerFactorial(x)
+        case ["echo", s] => s
+        case _ => "I don't know what you want to GET"
+    },
+    dispatch = fn(method, url) match ([method, url]) {
+        case ["GET", p] => dispatchGet(p)
+        case ["POST", _] => "Looks like you POST-ed me!"
+        case ["DELETE", _] => "Not interested in DELETE-ing!"
+        case ["OPTIONS", _] => "What OPTIONS are you looking for?"
+        case _ => "ERROR"
+    },
+    handler = fn(req, res) match (req) {
+        case {method, url} =>
+            res.end(dispatch(method, url))
     }
 ) do {
-    http.createServer(handler).listen(1337, "127.0.0.1");
-    print("Server started at http://127.0.0.1:1337/");
+    http.createServer(handler).listen(port, address);
+    console.log("Server running at http://127.0.0.1:1337/");
 }

--- a/examples/server.squiggle
+++ b/examples/server.squiggle
@@ -4,7 +4,6 @@ let (
     address = "127.0.0.1",
     Number = global.Number,
     String = global.String,
-    NL = String.fromCharCode(10),
     factorial = fn(n) match (n) {
         case 0 => 1
         case n => n * factorial(n - 1)
@@ -18,7 +17,7 @@ let (
             a = mod(s, 0),
             b = mod(s, n - 1)
         ) s.slice(a, n - b).split("/"),
-    dispatchGet = fn(url) match (tail(url.split("/"))) {
+    dispatchGet = fn(url) match (parsePath(url)) {
         case ["factorial", x] => handlerFactorial(x)
         case ["echo", s] => s
         case _ => "I don't know what you want to GET"

--- a/grammars/parser.pegjs
+++ b/grammars/parser.pegjs
@@ -83,7 +83,6 @@ MatchPatternNonterminal
     = MatchPatternArray
     / MatchPatternObject
 
-
 MatchPatternLiteral
     = x:(Number / String / NamedLiteral)
     { return ast.MatchPatternLiteral(x); }
@@ -114,7 +113,12 @@ MatchPatternObjectPair
     = k:String ":" _ v:MatchPattern
     { return ast.MatchPatternObjectPair(k, v); }
     / i:Identifier
-    { return ast.MatchPatternObjectPair(ast.String(i.data), i); }
+    {
+        return ast.MatchPatternObjectPair(
+            ast.String(i.data),
+            ast.MatchPatternSimple(i)
+        );
+    }
 
 Bindings
     = b:Binding bs:("," _ b2:Binding { return b2; })*

--- a/grammars/parser.pegjs
+++ b/grammars/parser.pegjs
@@ -73,8 +73,13 @@ MatchClause
 
 MatchPattern
     = MatchPatternSimple
+    / MatchPatternLiteral
     / MatchPatternArray
     / MatchPatternObject
+
+MatchPatternLiteral
+    = x:(Number / String / NamedLiteral)
+    { return ast.MatchPatternLiteral(x); }
 
 MatchPatternSimple
     = i:Identifier
@@ -235,6 +240,12 @@ Undefined "undefined"
 Null "null"
     = "null" _
     { return ast.Null(); }
+
+NamedLiteral
+    = True
+    / False
+    / Undefined
+    / Null
 
 Number "number"
     = n:$([0-9]+) _

--- a/grammars/parser.pegjs
+++ b/grammars/parser.pegjs
@@ -99,7 +99,7 @@ MatchPatternObjectItems
     { return cons(p, ps); }
 
 MatchPatternObjectPair
-    = k:Identifier ":" _ v:Identifier
+    = k:String ":" _ v:Identifier
     { return ast.MatchPatternObjectPair(k, v); }
     / i:Identifier
     { return ast.MatchPatternObjectPair(ast.String(i.data), i); }

--- a/grammars/parser.pegjs
+++ b/grammars/parser.pegjs
@@ -72,10 +72,17 @@ MatchClause
     { return ast.MatchClause(p, e); }
 
 MatchPattern
-    = MatchPatternSimple
-    / MatchPatternLiteral
-    / MatchPatternArray
+    = MatchPatternTerminal
+    / MatchPatternNonterminal
+
+MatchPatternTerminal
+    = MatchPatternLiteral
+    / MatchPatternSimple
+
+MatchPatternNonterminal
+    = MatchPatternArray
     / MatchPatternObject
+
 
 MatchPatternLiteral
     = x:(Number / String / NamedLiteral)
@@ -90,8 +97,8 @@ MatchPatternArray
     { return ast.MatchPatternArray(ps || []); }
 
 MatchPatternArrayItems
-    = p:MatchPatternSimple
-      ps:("," _ pp:MatchPatternSimple { return pp; })*
+    = p:MatchPattern
+      ps:("," _ pp:MatchPattern { return pp; })*
     { return cons(p, ps); }
 
 MatchPatternObject
@@ -104,7 +111,7 @@ MatchPatternObjectItems
     { return cons(p, ps); }
 
 MatchPatternObjectPair
-    = k:String ":" _ v:Identifier
+    = k:String ":" _ v:MatchPattern
     { return ast.MatchPatternObjectPair(k, v); }
     / i:Identifier
     { return ast.MatchPatternObjectPair(ast.String(i.data), i); }

--- a/grammars/parser.pegjs
+++ b/grammars/parser.pegjs
@@ -68,7 +68,7 @@ Match
     { return ast.Match(e, b); }
 
 MatchClause
-    = p:MatchPattern "=>" _ e:Expr
+    = "case" _ p:MatchPattern "=>" _ e:Expr
     { return ast.MatchClause(p, e); }
 
 MatchPattern

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squiggle",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An experimental programming language",
   "bin": "src/main.js",
   "scripts": {

--- a/runtime/predef.js
+++ b/runtime/predef.js
@@ -7,6 +7,9 @@ var print = function(x) { return sqgl$$log(x); };
 var not = function(x) { return !x; };
 // TODO: Polyfill.
 var is = Object.is;
+var isObject = function(x) {
+    return x && typeof x === "object";
+};
 var $lt = function(a, b) {
     var ta = typeof a;
     var tb = typeof b;
@@ -190,6 +193,7 @@ var sqgl$$assertBoolean = function(x) {
     }
     return x;
 };
+var sqgl$$isObject = isObject;
 var sqgl$$freeze = Object.freeze;
 var sqgl$$create = Object.create;
 var sqgl$$is = is;

--- a/runtime/predef.js
+++ b/runtime/predef.js
@@ -5,6 +5,8 @@ var undefined = void 0;
 var global = (1, eval)("this");
 var print = function(x) { return sqgl$$log(x); };
 var not = function(x) { return !x; };
+// TODO: Polyfill.
+var is = Object.is;
 var $lt = function(a, b) {
     var ta = typeof a;
     var tb = typeof b;
@@ -190,6 +192,7 @@ var sqgl$$assertBoolean = function(x) {
 };
 var sqgl$$freeze = Object.freeze;
 var sqgl$$create = Object.create;
+var sqgl$$is = is;
 var sqgl$$isArray = Array.isArray;
 var sqgl$$keys = Object.keys;
 var sqgl$$get = get;

--- a/src/ast.js
+++ b/src/ast.js
@@ -30,6 +30,7 @@ var ast = nm({
     Match: ["expression", "clauses"],
     MatchClause: ["pattern", "expression"],
     MatchPatternSimple: ["identifier"],
+    MatchPatternLiteral: ["data"],
     MatchPatternArray: ["patterns"],
     MatchPatternObject: ["pairs"],
     MatchPatternObjectPair: ["key", "value"],

--- a/src/ast.js
+++ b/src/ast.js
@@ -27,6 +27,13 @@ var ast = nm({
     Pair:        ["key", "value"],
     IdentifierExpression: ["data"],
 
+    Match: ["expression", "clauses"],
+    MatchClause: ["pattern", "expression"],
+    MatchPatternSimple: ["identifier"],
+    MatchPatternArray: ["patterns"],
+    MatchPatternObject: ["pairs"],
+    MatchPatternObjectPair: ["key", "value"],
+
     ReplHelp:       [],
     ReplQuit:       [],
     ReplBinding:    ["binding"],

--- a/src/es.js
+++ b/src/es.js
@@ -17,6 +17,8 @@ var es = nm({
     FunctionExpression: ['id', 'params', 'body'],
     VariableDeclaration: ['kind', 'declarations'],
     VariableDeclarator: ['id', 'init'],
+    BinaryExpression: ['operator', 'left', 'right'],
+    IfStatement: ['test', 'consequent', 'alternate'],
 });
 
 module.exports = es;

--- a/src/lint.js
+++ b/src/lint.js
@@ -87,6 +87,10 @@ function findUnusedOrUndeclaredBindings(ast) {
             identifiers.forEach(function(b) {
                 scopes.setBest(b.identifier.data, false);
             });
+        } else if (node.type === 'MatchClause') {
+            scopes = OverlayMap(scopes);
+        } else if (node.type === 'MatchPatternSimple') {
+            scopes.setBest(node.identifier.data, false);
         } else if (isIdentifierUsage(node, parent)) {
             // Only look at identifiers that are being used for their
             // values, not their names.
@@ -104,7 +108,7 @@ function findUnusedOrUndeclaredBindings(ast) {
         }
     }
     function exit(node, parent) {
-        if (isNewScope(node, parent)) {
+        if (isNewScope(node, parent) || node.type === 'MatchClause') {
             // Pop the scope stack and investigate for unused variables.
             scopes.ownKeys().forEach(function(k) {
                 if (isIdentifierOkayToNotUse(k) && !scopes.get(k)) {

--- a/src/match.js
+++ b/src/match.js
@@ -1,13 +1,13 @@
 var es = require("./es");
+var ast = require("./ast");
 
 function match(pattern, expression) {
-    return es.IfStatement(
-        satisfiesPattern(pattern),
-        es.ReturnStatement(
-            wrapExpression(pattern, expression)
-        ),
-        null
-    );
+    var id = es.Identifier("$match");
+    var expr = wrapExpression(id, pattern, expression);
+    var ret = es.ReturnStatement(expr);
+    var pred = satisfiesPattern(id, pattern);
+    var block = es.BlockStatement([ret]);
+    return es.IfStatement(pred, block, null);
 }
 
 function esAnd(a, b) {
@@ -16,6 +16,9 @@ function esAnd(a, b) {
 
 function esEq(a, b) {
     return es.BinaryExpression("===", a, b);
+}
+function esIn(a, b) {
+    return es.BinaryExpression("in", a, b);
 }
 
 function esProp(obj, prop) {
@@ -30,41 +33,48 @@ function objGet(obj, k) {
     return es.MemberExpression(true, obj, es.Literal(k));
 }
 
+function esTypeof(x) {
+    return {
+        type: "UnaryExpression",
+        prefix: true,
+        operator: "typeof",
+        argument: x,
+    };
+}
+
 var esTrue = es.Literal(true);
 
 var _satisfiesPattern = {
-    MatchPatternSimple: function(p) {
-        var x = es.Literal(p.identifier.data);
-        return esEq(x, x)
+    MatchPatternSimple: function(root, p) {
+        return esTrue;
     },
-    MatchPatternArray: function(p) {
-        if (p.patterns.length === 0) {
-            return esTrue;
-        }
+    MatchPatternArray: function(root, p) {
         var ps = p.patterns;
         var n = ps.length;
-        var id = es.Identifier("$match");
-        var lengthEq = esEq(esProp(id, "length"), es.Literal(n));
-        return ps
-            .map(satisfiesPattern)
-            .reduce(esAnd, lengthEq);
+        var lengthEq = esEq(esProp(root, "length"), es.Literal(n));
+        return lengthEq;
     },
-    MatchPatternObject: function(p) {
-        if (p.pairs.length === 0) {
-            return esTrue;
-        }
-        return p.pairs.map(satisfiesPattern).reduce(esAnd);
+    MatchPatternObject: function(root, p) {
+        var t = esTypeof(root);
+        var o = es.Literal("object");
+        var isObject = esAnd(root, esEq(t, o));
+        return p
+            .pairs
+            .map(function(p) {
+                return esIn(es.Literal(p.key.data), root);
+            })
+            .reduce(esAnd, isObject);
     },
-    MatchPatternObjectPair: function(p) {
+    MatchPatternObjectPair: function(root, p) {
         // TODO: Don't assume the key is a string literal.
         var s = es.Literal(p.key.data);
         return esEq(s, s);
     },
 };
 
-function satisfiesPattern(p) {
+function satisfiesPattern(root, p) {
     if (p.type in _satisfiesPattern) {
-        return _satisfiesPattern[p.type](p);
+        return _satisfiesPattern[p.type](root, p);
     }
     throw new Error("can't satisfiesPattern of " + p);
 }
@@ -88,7 +98,6 @@ var __pluckPattern = {
         return acc;
     },
     MatchPatternObjectPair: function(acc, root, p) {
-        console.error(p);
         acc.identifiers.push(es.Identifier(p.value.data));
         acc.expressions.push(objGet(root, p.key.data));
         return acc;
@@ -102,14 +111,13 @@ function _pluckPattern(acc, root, p) {
     throw new Error("can't pluckPattern of " + p);
 }
 
-function pluckPattern(p) {
+function pluckPattern(root, p) {
     var obj = {identifiers: [], expressions: []};
-    var root = es.Identifier("$match");
     return _pluckPattern(obj, root, p);
 }
 
-function wrapExpression(p, e) {
-    var obj = pluckPattern(p);
+function wrapExpression(root, p, e) {
+    var obj = pluckPattern(root, p);
     var ret = es.ReturnStatement(e);
     var block = es.BlockStatement([ret]);
     var fn = es.FunctionExpression(null, obj.identifiers, block);

--- a/src/match.js
+++ b/src/match.js
@@ -98,7 +98,7 @@ function satisfiesPattern(root, p) {
     if (p.type in _satisfiesPattern) {
         return _satisfiesPattern[p.type](root, p);
     }
-    throw new Error("can't satisfiesPattern of " + p);
+    throw new Error("can't satisfiesPattern of " + j(p));
 }
 
 var __pluckPattern = {
@@ -135,7 +135,7 @@ function _pluckPattern(acc, root, p) {
     if (p.type in __pluckPattern) {
         return __pluckPattern[p.type](acc, root, p);
     }
-    throw new Error("can't pluckPattern of " + p);
+    throw new Error("can't pluckPattern of " + j(p));
 }
 
 function pluckPattern(root, p) {

--- a/src/match.js
+++ b/src/match.js
@@ -102,7 +102,7 @@ var __pluckPattern = {
         acc.expressions.push(objGet(root, p.key.data));
         return acc;
     },
-}
+};
 
 function _pluckPattern(acc, root, p) {
     if (p.type in __pluckPattern) {

--- a/src/match.js
+++ b/src/match.js
@@ -1,0 +1,119 @@
+var es = require("./es");
+
+function match(pattern, expression) {
+    return es.IfStatement(
+        satisfiesPattern(pattern),
+        es.ReturnStatement(
+            wrapExpression(pattern, expression)
+        ),
+        null
+    );
+}
+
+function esAnd(a, b) {
+    return es.LogicalExpression("&&", a, b);
+}
+
+function esEq(a, b) {
+    return es.BinaryExpression("===", a, b);
+}
+
+function esProp(obj, prop) {
+    return es.MemberExpression(false, obj, es.Identifier(prop));
+}
+
+function arrayNth(a, i) {
+    return es.MemberExpression(true, a, es.Literal(i));
+}
+
+function objGet(obj, k) {
+    return es.MemberExpression(true, obj, es.Literal(k));
+}
+
+var esTrue = es.Literal(true);
+
+var _satisfiesPattern = {
+    MatchPatternSimple: function(p) {
+        var x = es.Literal(p.identifier.data);
+        return esEq(x, x)
+    },
+    MatchPatternArray: function(p) {
+        if (p.patterns.length === 0) {
+            return esTrue;
+        }
+        var ps = p.patterns;
+        var n = ps.length;
+        var id = es.Identifier("$match");
+        var lengthEq = esEq(esProp(id, "length"), es.Literal(n));
+        return ps
+            .map(satisfiesPattern)
+            .reduce(esAnd, lengthEq);
+    },
+    MatchPatternObject: function(p) {
+        if (p.pairs.length === 0) {
+            return esTrue;
+        }
+        return p.pairs.map(satisfiesPattern).reduce(esAnd);
+    },
+    MatchPatternObjectPair: function(p) {
+        // TODO: Don't assume the key is a string literal.
+        var s = es.Literal(p.key.data);
+        return esEq(s, s);
+    },
+};
+
+function satisfiesPattern(p) {
+    if (p.type in _satisfiesPattern) {
+        return _satisfiesPattern[p.type](p);
+    }
+    throw new Error("can't satisfiesPattern of " + p);
+}
+
+var __pluckPattern = {
+    MatchPatternSimple: function(acc, root, p) {
+        acc.identifiers.push(es.Identifier(p.identifier.data));
+        acc.expressions.push(root);
+        return acc;
+    },
+    MatchPatternArray: function(acc, root, p) {
+        p.patterns.forEach(function(x, i) {
+            _pluckPattern(acc, arrayNth(root, i), x);
+        });
+        return acc;
+    },
+    MatchPatternObject: function(acc, root, p) {
+        p.pairs.forEach(function(v) {
+            _pluckPattern(acc, root, v);
+        });
+        return acc;
+    },
+    MatchPatternObjectPair: function(acc, root, p) {
+        console.error(p);
+        acc.identifiers.push(es.Identifier(p.value.data));
+        acc.expressions.push(objGet(root, p.key.data));
+        return acc;
+    },
+}
+
+function _pluckPattern(acc, root, p) {
+    if (p.type in __pluckPattern) {
+        return __pluckPattern[p.type](acc, root, p);
+    }
+    throw new Error("can't pluckPattern of " + p);
+}
+
+function pluckPattern(p) {
+    var obj = {identifiers: [], expressions: []};
+    var root = es.Identifier("$match");
+    return _pluckPattern(obj, root, p);
+}
+
+function wrapExpression(p, e) {
+    var obj = pluckPattern(p);
+    var ret = es.ReturnStatement(e);
+    var block = es.BlockStatement([ret]);
+    var fn = es.FunctionExpression(null, obj.identifiers, block);
+    return es.CallExpression(fn, obj.expressions);
+}
+
+module.exports = match;

--- a/src/match.js
+++ b/src/match.js
@@ -48,6 +48,10 @@ var _satisfiesPattern = {
     MatchPatternSimple: function(root, p) {
         return esTrue;
     },
+    MatchPatternLiteral: function(root, p) {
+        var lit = es.Literal(p.data.data);
+        return es.CallExpression(es.Identifier("sqgl$$is"), [root, lit]);
+    },
     MatchPatternArray: function(root, p) {
         var ps = p.patterns;
         var n = ps.length;
@@ -83,6 +87,10 @@ var __pluckPattern = {
     MatchPatternSimple: function(acc, root, p) {
         acc.identifiers.push(es.Identifier(p.identifier.data));
         acc.expressions.push(root);
+        return acc;
+    },
+    MatchPatternLiteral: function(acc, root, p) {
+        // Literals are just for the expression, they don't bind any values.
         return acc;
     },
     MatchPatternArray: function(acc, root, p) {

--- a/src/repl.js
+++ b/src/repl.js
@@ -10,7 +10,7 @@ var prettyPrint = require("./pretty-print");
 function transformAndEval(ast) {
     var es = transformAst(ast);
     var js = compile(es);
-    console.log(chalk.bold("JAVASCRIPT\n"), chalk.cyan(js));
+    console.log(chalk.bold("JAVASCRIPT\n") + chalk.cyan(js));
     return globalEval(js);
 }
 

--- a/src/repl.js
+++ b/src/repl.js
@@ -7,10 +7,14 @@ var compile = require("./compile");
 var transformAst = require("./transform-ast");
 var prettyPrint = require("./pretty-print");
 
+var SHOW_JS = true;
+
 function transformAndEval(ast) {
     var es = transformAst(ast);
     var js = compile(es);
-    console.log(chalk.bold("JAVASCRIPT\n") + chalk.cyan(js));
+    if (SHOW_JS) {
+        console.log(chalk.cyan(js));
+    }
     return globalEval(js);
 }
 
@@ -75,7 +79,6 @@ function processLine(rl, text) {
     }
 
     try {
-        console.log(prettyPrint(ast));
         console.log(prettyPrint(transformAndEval(ast)));
     } catch (e) {
         console.log(error(e.stack));

--- a/src/repl.js
+++ b/src/repl.js
@@ -10,6 +10,7 @@ var prettyPrint = require("./pretty-print");
 function transformAndEval(ast) {
     var es = transformAst(ast);
     var js = compile(es);
+    console.log(chalk.bold("JAVASCRIPT\n"), chalk.cyan(js));
     return globalEval(js);
 }
 
@@ -74,6 +75,7 @@ function processLine(rl, text) {
     }
 
     try {
+        console.log(prettyPrint(ast));
         console.log(prettyPrint(transformAndEval(ast)));
     } catch (e) {
         console.log(error(e.stack));

--- a/src/transform-ast.js
+++ b/src/transform-ast.js
@@ -6,6 +6,7 @@ var jsbeautify = require("js-beautify");
 var esprima = require("esprima");
 var es = require("./es");
 var ast = require("./ast");
+var match = require("./match");
 
 function transformAst(node) {
     if (!isObject(node)) {
@@ -284,28 +285,29 @@ var handlers = {
         // TODO
         var e = transformAst(node.expression);
         var body = node.clauses.map(transformAst);
-        var block = es.BlockStatement(body);
+        var matchError = esprima.parse(
+            "throw new sqgl$$Error('pattern match failure');"
+        ).body;
+        var block = es.BlockStatement(body.concat(matchError));
         var id = es.Identifier("$match");
         var fn = es.FunctionExpression(null, [id], block);
         return es.CallExpression(fn, [e]);
     },
     MatchClause: function(node) {
-        // TODO
-        var j = JSON.stringify;
-        var s = "" + j(node.pattern) + " => " + j(node.expression);
-        return es.ExpressionStatement(es.Literal(s));
+        var e = transformAst(node.expression);
+        return match(node.pattern, e);
     },
     MatchPatternSimple: function(node) {
-        // TODO
+        throw new Error("you shouldn't be here");
     },
     MatchPatternArray: function(node) {
-        // TODO
+        throw new Error("you shouldn't be here");
     },
     MatchPatternObject: function(node) {
-        // TODO
+        throw new Error("you shouldn't be here");
     },
     MatchPatternObjectPair: function(node) {
-        // TODO
+        throw new Error("you shouldn't be here");
     },
     True: function(node) {
         return es.Literal(true);

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -76,25 +76,28 @@ function _walk(parents, obj, ast) {
             recur(node.binding);
         },
         Match: function(node) {
-            // TODO
+            recur(node.expression);
+            node.clauses.forEach(recur);
         },
         MatchClause: function(node) {
-            // TODO
+            recur(node.pattern);
+            recur(node.expression);
         },
         MatchPatternSimple: function(node) {
-            // TODO
+            recur(node.identifier);
         },
         MatchPatternLiteral: function(node) {
-            // TODO
+            recur(node.data);
         },
         MatchPatternArray: function(node) {
-            // TODO
+            node.patterns.forEach(recur);
         },
         MatchPatternObject: function(node) {
-            // TODO
+            node.pairs.forEach(recur);
         },
         MatchPatternObjectPair: function(node) {
-            // TODO
+            recur(node.key);
+            recur(node.value);
         },
         True: function(node) {},
         False: function(node) {},

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -75,6 +75,27 @@ function _walk(parents, obj, ast) {
         ReplBinding: function(node) {
             recur(node.binding);
         },
+        Match: function(node) {
+            // TODO
+        },
+        MatchClause: function(node) {
+            // TODO
+        },
+        MatchPatternSimple: function(node) {
+            // TODO
+        },
+        MatchPatternLiteral: function(node) {
+            // TODO
+        },
+        MatchPatternArray: function(node) {
+            // TODO
+        },
+        MatchPatternObject: function(node) {
+            // TODO
+        },
+        MatchPatternObjectPair: function(node) {
+            // TODO
+        },
         True: function(node) {},
         False: function(node) {},
         Null: function(node) {},


### PR DESCRIPTION
This PR adds basic nested pattern matching support. Forms are as follows:

Overall structure looks like:

```
match (V) {
  case P1 => X1
  case P2 => X2
  case P3 => X3
}
```

`[p1, p2, p3]`

Matches an array of size 3 and binds the three patterns inside.

`{a, b, "c": p1}`

Matches an object with at least the properties "a", "b", and "c", applying the p1 pattern to the value at "c".

x

Just a plain variable name. Always passes and is bound with the value at its position in the pattern.

_x or  _

Technically also just a variable name pattern, but used to ignore values.

`"hello"` or `true` or `342` or other named literals

Assert the value at that position in the pattern is equal to that.
