### PR TITLE
Update readme for missing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ This project uses the [Contributor Covenant](https://github.com/saikobee/squiggl
 - Click the "Fork" repository button and locally clone your fork
 - Use a terminal and `cd` into the new directory
 - Install [Node.js](https://nodejs.org/en/)
-- npm install (this will install the dependencies needed)
+- `npm install` (this will install the dependencies needed)
 - `node src/main.js`
 - Optional: `npm link` so you can just run `squiggle`

--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ This project uses the [Contributor Covenant](https://github.com/saikobee/squiggl
 - Click the "Fork" repository button and locally clone your fork
 - Use a terminal and `cd` into the new directory
 - Install [Node.js](https://nodejs.org/en/)
+- npm install (this will install the dependencies needed)
 - `node src/main.js`
 - Optional: `npm link` so you can just run `squiggle`


### PR DESCRIPTION
Add npm install to the readme for users trying to build locally. Experienced users won’t need it, but new people will to know how to actually run this.
