### PR TITLE
Fixes #26 fn call, prop access, method access, all have same precedence

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -182,7 +182,7 @@ var MatchPatternObjectPairShorthand =
     Identifier
     .map(function(i) {
         var str = ast.String(i.data);
-        var expr = ast.IdentifierExpression(i);
+        var expr = ast.MatchPatternSimple(i);
         return ast.MatchPatternObjectPair(str, expr);
     });
 

--- a/src/transform/call.js
+++ b/src/transform/call.js
@@ -2,6 +2,10 @@ var es = require("../es");
 var ast = require("../ast");
 
 function Call(transform, node) {
+    // Id the function being called comes from a "GetProperty", that means we're
+    // looking at a method invocation, like `foo.bar()` rather than just a
+    // normal function invocation like `goop()`, so transform this node into a
+    // `ast.CallMethod` and let it do the work.
     if (node.f.type === "GetProperty") {
         var obj = node.f.obj;
         var prop = node.f.prop;

--- a/src/transform/call.js
+++ b/src/transform/call.js
@@ -2,7 +2,7 @@ var es = require("../es");
 var ast = require("../ast");
 
 function Call(transform, node) {
-    // Id the function being called comes from a "GetProperty", that means we're
+    // If the function being called comes from a "GetProperty", that means we're
     // looking at a method invocation, like `foo.bar()` rather than just a
     // normal function invocation like `goop()`, so transform this node into a
     // `ast.CallMethod` and let it do the work.

--- a/src/transform/call.js
+++ b/src/transform/call.js
@@ -5,9 +5,9 @@ function Call(transform, node) {
     if (node.f.type === "GetProperty") {
         var obj = node.f.obj;
         var prop = node.f.prop;
-        var args = node.args;
-        var node = ast.CallMethod(obj, prop, args);
-        return transform(node);
+        var cmArgs = node.args;
+        var cmNode = ast.CallMethod(obj, prop, cmArgs);
+        return transform(cmNode);
     }
     var f = transform(node.f);
     var args = node.args.map(transform);

--- a/src/transform/call.js
+++ b/src/transform/call.js
@@ -1,6 +1,14 @@
 var es = require("../es");
+var ast = require("../ast");
 
 function Call(transform, node) {
+    if (node.f.type === "GetProperty") {
+        var obj = node.f.obj;
+        var prop = node.f.prop;
+        var args = node.args;
+        var node = ast.CallMethod(obj, prop, args);
+        return transform(node);
+    }
     var f = transform(node.f);
     var args = node.args.map(transform);
     return es.CallExpression(f, args);


### PR DESCRIPTION
This example works now:

```
def r(s) = require s
in "0x" ++ r("util").inspect["colors"].blue.slice(0)[0].toString(16)
```
