### PR TITLE
Add type checking to `has`

### DIFF
--- a/src/predef.js
+++ b/src/predef.js
@@ -103,15 +103,11 @@ module.exports = {
         dependencies: [],
         code: [
             'function $has(obj, key) {',
-            '    if (typeof key !== "string" &&',
-            '        typeof key !== "number") {',
-            '       throw new Error("key must be a string or a number. " +',
-            '                       "Key is a " + typeof key);',
+            '    if (typeof key === "string" ||',
+            '        typeof key === "number" && key % 1 === 0) {',
+            '        return obj[key] !== undefined;',
             '    }',
-            '    if (typeof key === "number" && !(key % 1 === 0)) {',
-            '        throw new Error("Numerical keys cannot be floats");',
-            '    }',
-            '    return obj[key] !== undefined;',
+            '    throw new Error("Key must be a string or integer, got " + typeof key);',
             '}'
         ].join("\n")
     },

--- a/src/predef.js
+++ b/src/predef.js
@@ -101,7 +101,19 @@ module.exports = {
     },
     has: {
         dependencies: [],
-        code: 'function $has(obj, key) { return obj[key] !== undefined; }'
+        code: [
+            'function $has(obj, key) {',
+            '    if (typeof key !== "string" &&',
+            '        typeof key !== "number") {',
+            '       throw new Error("key must be a string or a number. " +',
+            '                       "Key is a " + typeof key);',
+            '    }',
+            '    if (typeof key === "number" && !(key % 1 === 0)) {',
+            '        throw new Error("Numerical keys cannot be floats");',
+            '    }',
+            '    return obj[key] !== undefined;',
+            '}'
+        ].join("\n")
     },
     is: {
         dependencies: [],

--- a/src/predef.js
+++ b/src/predef.js
@@ -107,7 +107,8 @@ module.exports = {
             '        typeof key === "number" && key % 1 === 0) {',
             '        return obj[key] !== undefined;',
             '    }',
-            '    throw new Error("Key must be a string or integer, got " + typeof key);',
+            '    throw new Error("Key must be a string or integer" +',
+            '                    ", got " + typeof key);',
             '}'
         ].join("\n")
     },


### PR DESCRIPTION
$has now throws an error when a key is not a string or an integer

Closes issue #68 on github

Here's an example of new behavior. 4 still matches "4". Don't know if that should be fixed?

Using haskell syntax highlighting because I don't know of anything closer

``` haskell
let a = global has "console"
let b = {"4": "four"} has "4"
let c = {"4": "four"} has 4
let d = {"4": "four"} has 4.0

#-- These both throw runtime errors
#-- let e = {"4": "four"} has 4.1
#-- let f = global has []
let results = a.toString() ++ b.toString() ++ c.toString() ++ d.toString()
in global.console.log(results)
```
