### PR TITLE
Add the ability to run squiggle files straight

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "esprima": "^2.3.0",
     "estraverse": "^4.1.1",
     "lodash": "^3.9.3",
+    "node-hook": "^0.2.0",
     "nomnom": "^1.8.1",
     "parsimmon": "^0.7.0"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,7 @@ var nomnom = require("nomnom")
     .option("output", {
         position: 1,
         metavar: "FILE",
-        help: "Write JavaScript to this file",
+        help: "Write JavaScript to this file, if omitted then run the input",
         type: "string"
     })
     .option("interactive", {
@@ -56,7 +56,6 @@ function die(message) {
 }
 
 function compileTo(src, dest) {
-    var jsOut = dest;
     // TODO: Allow disabling embedded sourcemaps.
     var txt = normalizeCode(fs.readFileSync(src, "utf-8"));
     var stuff = compile(txt, src, {embedSourceMaps: true});
@@ -69,7 +68,11 @@ function compileTo(src, dest) {
             ].join(":");
             error('warning: ' + msg);
         });
-        fs.writeFileSync(jsOut, stuff.code, UTF8);
+        if (dest !== undefined) {
+            fs.writeFileSync(dest, stuff.code, UTF8);
+        } else {
+            eval(stuff.code);
+        }
     } else {
         var result = stuff.result;
         var expectations = uniq(result.expected).join(", ");
@@ -92,6 +95,8 @@ function compileTo(src, dest) {
 
 if (argv.interactive) {
     repl.start();
+} else if (argv._.length === 1) {
+    compileTo(argv._[0], undefined);
 } else if (argv._.length === 2) {
     compileTo(argv._[0], argv._[1]);
 } else {

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ var UTF8 = "utf-8";
 
 var pkg = require("../package.json");
 var fs = require("fs");
+var vm = require("vm");
 var chalk = require("chalk");
 var uniq = require("lodash/array/uniq");
 var nomnom = require("nomnom")
@@ -71,7 +72,8 @@ function compileTo(src, dest) {
         if (dest !== undefined) {
             fs.writeFileSync(dest, stuff.code, UTF8);
         } else {
-            eval(stuff.code);
+            var script = new vm.Script(stuff.code);
+            script.runInThisContext();
         }
     } else {
         var result = stuff.result;

--- a/src/main.js
+++ b/src/main.js
@@ -13,14 +13,15 @@ var nomnom = require("nomnom")
     .option("input", {
         position: 0,
         metavar: "FILE",
-        help: "Compile this Squiggle file",
+        help: "Execute this Squiggle file",
         type: "string"
     })
     .option("output", {
-        position: 1,
         metavar: "FILE",
-        help: "Write JavaScript to this file, if omitted then run the input",
-        type: "string"
+        abbr: "o",
+        help: "Write JavaScript to this file",
+        type: "string",
+        flag: true
     })
     .option("interactive", {
         abbr: "i",


### PR DESCRIPTION
Calling squiggle with only one argument will eval the compiled
code instead of writting it to a file.

This also allows squiggle to be used from a shebang

> example.sql
> 
> ``` shell
> #!/usr/bin/env squiggle
> global.console.log("Hello, World!")
> ```

```
$ chmod +x example.sql
$ ./example.sql
Hello, World!
```
